### PR TITLE
Add foreground audio controls and PowerMate gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ Posting events may require **Input Monitoring** (or **Accessibility**) in **Syst
 
 ### Versions
 
+#### 1.1.0
+
+**Foreground-aware audio control and gestures**:
+
+- Turning controls Apple Music or Spotify volume when that player is in the foreground; other apps use smooth system-volume control.
+- Click controls Play/Pause and double-click skips to the next track, including when the active player is in the background.
+- Triple-click opens Apple Music.
+- Press and turn skips forward or backward through tracks.
+- Option + turn controls display brightness.
+- Long press opens Siri; a very long press (1.5 seconds) toggles the default microphone mute state when supported by the input device.
+- System volume uses a short 120 Hz easing ramp for smoother fine-grained changes.
+
 #### 1.0.16
 
 **Long press to switch scroll mode**: You can now configure the long press to switch between fine and coarse scrolling.

--- a/Sources/PowerMateAgent/AudioControl.swift
+++ b/Sources/PowerMateAgent/AudioControl.swift
@@ -32,12 +32,79 @@ func postMediaKey(_ keyType: Int32, keyDown: Bool, modifiers: NSEvent.ModifierFl
 
 // MARK: - Volume control
 
+private func scalarVolumeAddress(_ element: AudioObjectPropertyElement = kAudioObjectPropertyElementMain) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyVolumeScalar,
+                               mScope: kAudioDevicePropertyScopeOutput,
+                               mElement: element)
+}
+
+private func readSystemVolume() -> Float32? {
+    guard let device = outputDevice() else { return nil }
+    for element: AudioObjectPropertyElement in [kAudioObjectPropertyElementMain, 1] {
+        var address = scalarVolumeAddress(element)
+        var value: Float32 = 0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        if AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value) == noErr { return value }
+    }
+    return nil
+}
+
+private func writeSystemVolume(_ value: Float32) -> Bool {
+    guard let device = outputDevice() else { return false }
+    func write(_ element: AudioObjectPropertyElement) -> Bool {
+        var address = scalarVolumeAddress(element)
+        var settable = DarwinBoolean(false)
+        guard AudioObjectIsPropertySettable(device, &address, &settable) == noErr, settable.boolValue else { return false }
+        var next = min(1, max(0, value))
+        return AudioObjectSetPropertyData(device, &address, 0, nil, UInt32(MemoryLayout<Float32>.size), &next) == noErr
+    }
+    if write(kAudioObjectPropertyElementMain) { return true }
+    let left = write(1), right = write(2)
+    return left || right
+}
+
+private final class SystemVolumeSmoother {
+    private var timer: Timer?
+    private var current: Float32 = 0
+    private var target: Float32 = 0
+
+    func add(_ delta: Float32) -> Bool {
+        if timer == nil {
+            guard let actual = readSystemVolume() else { return false }
+            current = actual; target = actual
+        }
+        target = min(1, max(0, target + delta))
+        if timer == nil {
+            let t = Timer(timeInterval: 1.0 / 120.0, repeats: true) { [weak self] _ in self?.tick() }
+            RunLoop.main.add(t, forMode: .common); timer = t
+        }
+        return true
+    }
+
+    private func tick() {
+        let distance = target - current
+        if abs(distance) < 0.00002 {
+            current = target; _ = writeSystemVolume(current); timer?.invalidate(); timer = nil; return
+        }
+        current += distance * 0.28
+        _ = writeSystemVolume(current)
+    }
+}
+
+private let systemVolumeSmoother = SystemVolumeSmoother()
+
 // Posts NX volume key events — identical to the physical keyboard volume keys.
 // fine=false: standard step (~6.25%, same as F11/F12).
 // fine=true:  shift+option step (~1.5625%, same as Shift+Option+F11/F12).
 // Repeated presses for delta > 1 give velocity-proportional movement in normal mode.
 func adjustVolume(up: Bool, fine: Bool, presses: Int = 1) {
+    // Apple Music and Spotify have their own volume controls. If either is in
+    // the foreground, change that player immediately instead of system volume.
+    if adjustForegroundAppVolume(up: up, fine: fine, presses: presses) { return }
     if up && _isMuted { setMuted(false) }
+    let percent = fine ? 0.001 : 0.002
+    let amount = Float32(percent * Double(max(1, presses)))
+    if systemVolumeSmoother.add(up ? amount : -amount) { return }
     let keyType: Int32 = up ? 0 : 1  // NX_KEYTYPE_SOUND_UP / NX_KEYTYPE_SOUND_DOWN
     let modFlags: NSEvent.ModifierFlags = fine ? [.shift, .option] : []
     for _ in 0 ..< max(1, presses) {

--- a/Sources/PowerMateAgent/ForegroundAppVolume.swift
+++ b/Sources/PowerMateAgent/ForegroundAppVolume.swift
@@ -1,0 +1,104 @@
+import Foundation
+import AppKit
+
+/// Applications that expose their own player volume through Apple Events.
+/// Unsupported foreground apps deliberately fall back to system volume.
+private enum ForegroundAudioApp {
+    case music, spotify
+
+    init?(bundleIdentifier: String?) {
+        switch bundleIdentifier {
+        case "com.apple.Music": self = .music
+        case "com.spotify.client": self = .spotify
+        default: return nil
+        }
+    }
+
+    var appleScriptName: String {
+        switch self { case .music: return "Music"; case .spotify: return "Spotify" }
+    }
+}
+
+private let foregroundVolumeQueue = DispatchQueue(label: "com.powermate.foreground-volume", qos: .userInteractive)
+
+/// Adjust the active player's own volume. Returns false when the active app has
+/// no supported per-app volume API, allowing the caller to control system volume.
+func adjustForegroundAppVolume(up: Bool, fine: Bool, presses: Int) -> Bool {
+    guard let app = ForegroundAudioApp(bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier) else {
+        return false
+    }
+    let step = fine ? 1 : 2
+    let delta = (up ? 1 : -1) * step * max(1, presses)
+    let name = app.appleScriptName
+    foregroundVolumeQueue.async {
+        let source = """
+        tell application "\(name)"
+            set newVolume to (sound volume) + (\(delta))
+            if newVolume > 100 then set newVolume to 100
+            if newVolume < 0 then set newVolume to 0
+            set sound volume to newVolume
+        end tell
+        """
+        var error: NSDictionary?
+        NSAppleScript(source: source)?.executeAndReturnError(&error)
+        if let error { NSLog("PowerMate: could not control %@ volume: %@", name, error) }
+    }
+    return true
+}
+
+/// Send playback commands to the player that is actually playing, even when it
+/// is in the background. The foreground player is the fallback when paused.
+func controlForegroundPlayer(nextTrack: Bool) -> Bool {
+    let runningIDs = Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+    let candidates: [ForegroundAudioApp] = [
+        runningIDs.contains("com.apple.Music") ? .music : nil,
+        runningIDs.contains("com.spotify.client") ? .spotify : nil,
+    ].compactMap { $0 }
+    guard !candidates.isEmpty else { return false }
+    let foreground = ForegroundAudioApp(bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+    let command = nextTrack ? "next track" : "playpause"
+    foregroundVolumeQueue.async {
+        var selected = foreground ?? candidates[0]
+        for candidate in candidates {
+            let stateSource = "tell application \"\(candidate.appleScriptName)\" to return (player state as text)"
+            var stateError: NSDictionary?
+            let state = NSAppleScript(source: stateSource)?.executeAndReturnError(&stateError).stringValue
+            if state?.lowercased() == "playing" {
+                selected = candidate
+                break
+            }
+        }
+        let name = selected.appleScriptName
+        let source = "tell application \"\(name)\" to \(command)"
+        var error: NSDictionary?
+        NSAppleScript(source: source)?.executeAndReturnError(&error)
+        if let error { NSLog("PowerMate: could not send %@ to %@: %@", command, name, error) }
+    }
+    return true
+}
+
+/// Previous-track companion used by press-and-turn.
+func controlForegroundPlayer(previousTrack: Bool) -> Bool {
+    guard previousTrack else { return false }
+    let runningIDs = Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+    let candidates: [ForegroundAudioApp] = [
+        runningIDs.contains("com.apple.Music") ? .music : nil,
+        runningIDs.contains("com.spotify.client") ? .spotify : nil,
+    ].compactMap { $0 }
+    guard !candidates.isEmpty else { return false }
+    foregroundVolumeQueue.async {
+        var selected = candidates[0]
+        for candidate in candidates {
+            let source = "tell application \"\(candidate.appleScriptName)\" to return (player state as text)"
+            var error: NSDictionary?
+            if NSAppleScript(source: source)?.executeAndReturnError(&error).stringValue?.lowercased() == "playing" {
+                selected = candidate; break
+            }
+        }
+        let source = "tell application \"\(selected.appleScriptName)\" to previous track"
+        var error: NSDictionary?
+        NSAppleScript(source: source)?.executeAndReturnError(&error)
+        if let error { NSLog("PowerMate: could not go to previous track: %@", error) }
+    }
+    return true
+}

--- a/Sources/PowerMateAgent/MicrophoneControl.swift
+++ b/Sources/PowerMateAgent/MicrophoneControl.swift
@@ -1,0 +1,71 @@
+import Foundation
+import CoreAudio
+
+private var microphoneMutedByPowerMate = false
+private var savedMicrophoneVolume: Float32 = 0.75
+
+private func defaultInputDevice() -> AudioDeviceID? {
+    var device = AudioDeviceID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    var address = AudioObjectPropertyAddress(mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                                             mScope: kAudioObjectPropertyScopeGlobal,
+                                             mElement: kAudioObjectPropertyElementMain)
+    guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &device) == noErr,
+          device != kAudioObjectUnknown else { return nil }
+    return device
+}
+
+private func setInputMute(_ muted: Bool, device: AudioDeviceID, element: AudioObjectPropertyElement) -> Bool {
+    var address = AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyMute,
+                                             mScope: kAudioDevicePropertyScopeInput,
+                                             mElement: element)
+    var settable = DarwinBoolean(false)
+    guard AudioObjectHasProperty(device, &address),
+          AudioObjectIsPropertySettable(device, &address, &settable) == noErr,
+          settable.boolValue else { return false }
+    var value: UInt32 = muted ? 1 : 0
+    return AudioObjectSetPropertyData(device, &address, 0, nil, UInt32(MemoryLayout<UInt32>.size), &value) == noErr
+}
+
+private func setInputVolume(_ value: Float32, device: AudioDeviceID, element: AudioObjectPropertyElement) -> Bool {
+    var address = AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyVolumeScalar,
+                                             mScope: kAudioDevicePropertyScopeInput,
+                                             mElement: element)
+    var settable = DarwinBoolean(false)
+    guard AudioObjectHasProperty(device, &address),
+          AudioObjectIsPropertySettable(device, &address, &settable) == noErr,
+          settable.boolValue else { return false }
+    var next = min(1, max(0, value))
+    return AudioObjectSetPropertyData(device, &address, 0, nil, UInt32(MemoryLayout<Float32>.size), &next) == noErr
+}
+
+private func inputVolume(device: AudioDeviceID, element: AudioObjectPropertyElement) -> Float32? {
+    var address = AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyVolumeScalar,
+                                             mScope: kAudioDevicePropertyScopeInput,
+                                             mElement: element)
+    var value: Float32 = 0
+    var size = UInt32(MemoryLayout<Float32>.size)
+    return AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value) == noErr ? value : nil
+}
+
+func toggleMicrophoneMute() {
+    guard let device = defaultInputDevice() else { return }
+    let muted = !microphoneMutedByPowerMate
+    var changed = setInputMute(muted, device: device, element: kAudioObjectPropertyElementMain)
+    if !changed {
+        if muted, let current = inputVolume(device: device, element: kAudioObjectPropertyElementMain), current > 0 {
+            savedMicrophoneVolume = current
+        }
+        let value: Float32 = muted ? 0 : max(0.05, savedMicrophoneVolume)
+        changed = setInputVolume(value, device: device, element: kAudioObjectPropertyElementMain)
+        if !changed {
+            let left = setInputVolume(value, device: device, element: 1)
+            let right = setInputVolume(value, device: device, element: 2)
+            changed = left || right
+        }
+    }
+    if changed {
+        microphoneMutedByPowerMate = muted
+        setLEDOffMain(muted ? 0 : 80)
+    }
+}

--- a/Sources/PowerMateAgent/Settings.swift
+++ b/Sources/PowerMateAgent/Settings.swift
@@ -19,7 +19,8 @@ let kFineScroll        = "fineScrollEnabled"
 // MARK: - Persistent state
 
 var scrollReversed      = defaults.bool(forKey: kScrollReversed)
-var audioControlEnabled = defaults.bool(forKey: kAudioControl)
+// The knob is a volume controller by default. Users can still toggle scroll mode.
+var audioControlEnabled = defaults.object(forKey: kAudioControl) == nil ? true : defaults.bool(forKey: kAudioControl)
 // VU meter defaults to true for existing users; only false if explicitly disabled.
 var vuMeterEnabled      = defaults.object(forKey: kVUMeter) == nil ? true : defaults.bool(forKey: kVUMeter)
 // When true, the default turn is fine step and Shift is standard step (swapped from default).

--- a/Sources/PowerMateAgent/main.swift
+++ b/Sources/PowerMateAgent/main.swift
@@ -46,10 +46,22 @@ driver.onRotate = { delta, rate in
         _didRotateWhileButtonDown = true
         _trackSkipAccumulator += delta
         while abs(_trackSkipAccumulator) >= kTrackSkipThreshold {
-            let keyType: Int32 = _trackSkipAccumulator > 0 ? 17 : 18  // NX_KEYTYPE_NEXT / NX_KEYTYPE_PREVIOUS
+            if _trackSkipAccumulator > 0 {
+                if !controlForegroundPlayer(nextTrack: true) {
+                    postMediaKey(17, keyDown: true); postMediaKey(17, keyDown: false)
+                }
+            } else if !controlForegroundPlayer(previousTrack: true) {
+                postMediaKey(18, keyDown: true); postMediaKey(18, keyDown: false)
+            }
+            _trackSkipAccumulator -= _trackSkipAccumulator > 0 ? kTrackSkipThreshold : -kTrackSkipThreshold
+        }
+        return
+    }
+    if NSEvent.modifierFlags.contains(.option) {
+        let keyType: Int32 = delta > 0 ? 2 : 3  // display brightness up/down
+        for _ in 0 ..< abs(delta) {
             postMediaKey(keyType, keyDown: true)
             postMediaKey(keyType, keyDown: false)
-            _trackSkipAccumulator -= _trackSkipAccumulator > 0 ? kTrackSkipThreshold : -kTrackSkipThreshold
         }
         return
     }
@@ -87,72 +99,63 @@ driver.onRotate = { delta, rate in
     }
 }
 
+private var pendingClickResolution: DispatchWorkItem?
+private var clickCount = 0
+private let multiClickInterval: TimeInterval = 0.28
+private var buttonDownStartedAt: CFAbsoluteTime?
+private let veryLongPressInterval: TimeInterval = 1.5
+
 driver.onClick = {
-    // Defer by one run-loop cycle so that any rotation in the same HID report is processed
-    // first (the driver handles button-change before rotation within each report block).
-    // This ensures _didRotateWhileButtonDown is set before we decide whether to act.
     DispatchQueue.main.async {
         guard !_didRotateWhileButtonDown else { return }
-        if useMenuBehavior() {
-            postKey(kReturnKey)
-            // Do not exit menu mode here: a submenu may open and we need to keep sending arrow keys.
-            // Menu mode will exit on the 5-second timeout when the user stops rotating.
-        } else if useAudioBehavior() {
-            let shiftHeld = NSEvent.modifierFlags.contains(.shift)
-            switch clickAction {
-            case .mute:      shiftHeld ? togglePlayPause() : toggleMute()
-            case .playPause: shiftHeld ? toggleMute()      : togglePlayPause()
-            }
-        } else {
-            exitMenuMode()
-            postMouseClick(button: .left)
+        pendingClickResolution?.cancel()
+        clickCount += 1
+        if clickCount >= 3 {
+            clickCount = 0
+            pendingClickResolution = nil
+            NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: "/System/Applications/Music.app"),
+                                               configuration: NSWorkspace.OpenConfiguration())
+            return
         }
+
+        let resolution = DispatchWorkItem {
+            let resolvedCount = clickCount
+            clickCount = 0
+            pendingClickResolution = nil
+            if resolvedCount == 1 {
+                if !controlForegroundPlayer(nextTrack: false) { togglePlayPause() }
+            } else if resolvedCount == 2, !controlForegroundPlayer(nextTrack: true) {
+                postMediaKey(17, keyDown: true)
+                postMediaKey(17, keyDown: false)
+            }
+        }
+        pendingClickResolution = resolution
+        DispatchQueue.main.asyncAfter(deadline: .now() + multiClickInterval, execute: resolution)
     }
 }
 
 driver.onLongPress = {
     DispatchQueue.main.async {
         guard !_didRotateWhileButtonDown else { return }
-        switch longPressAction {
-        case .rightClick:
-            enterMenuMode()
-            postMouseClick(button: .right)
-        case .doubleClick:
-            enterMenuMode()
-            DispatchQueue.main.async {
-                let cocoa = NSEvent.mouseLocation
-                let location = cocoaToQuartz(cocoa)
-                postDoubleClick(at: location)
-            }
-        case .toggleAudioMode:
-            DispatchQueue.main.async {
-                audioControlEnabled.toggle()
-                defaults.set(audioControlEnabled, forKey: kAudioControl)
-                if audioControlEnabled {
-                    if #available(macOS 14.2, *) { startAudioMeter() }
-                } else {
-                    stopAudioMeter()
-                }
-                signalModeChange(toAudio: audioControlEnabled)
-                menuHandler.updateMenuState()
-            }
-        case .toggleFineScroll:
-            DispatchQueue.main.async {
-                fineScrollEnabled.toggle()
-                defaults.set(fineScrollEnabled, forKey: kFineScroll)
-                menuHandler.updateMenuState()
-            }
-        case .runScript:
-            let command = NSEvent.modifierFlags.contains(.shift)
-                ? defaults.string(forKey: kScript2) ?? ""
-                : defaults.string(forKey: kScript1) ?? ""
-            runScript(command)
+        pendingClickResolution?.cancel()
+        pendingClickResolution = nil
+        clickCount = 0
+        let duration = CFAbsoluteTimeGetCurrent() - (buttonDownStartedAt ?? CFAbsoluteTimeGetCurrent())
+        if duration >= veryLongPressInterval {
+            toggleMicrophoneMute()
+            return
+        }
+        let siriURL = URL(fileURLWithPath: "/System/Applications/Siri.app")
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.openApplication(at: siriURL, configuration: configuration) { _, error in
+            if let error { NSLog("PowerMate: could not open Siri: %@", error.localizedDescription) }
         }
     }
 }
 
 driver.onButtonDown = {
     isButtonDown = true
+    buttonDownStartedAt = CFAbsoluteTimeGetCurrent()
     _didRotateWhileButtonDown = false
     _trackSkipAccumulator = 0
     setLEDOffMain(255)
@@ -160,6 +163,7 @@ driver.onButtonDown = {
 
 driver.onButtonUp = {
     isButtonDown = false
+    buttonDownStartedAt = nil
     if throbTimer != nil {
         lastRotationTime = CFAbsoluteTimeGetCurrent()
     } else {

--- a/scripts/Info.plist
+++ b/scripts/Info.plist
@@ -13,15 +13,17 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.16</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>PowerMate Agent captures system audio output to drive the LED as a volume meter.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>PowerMate Agent controls the volume of the foreground music application.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 James Lockman Consulting. All rights reserved. This software is provided "as is" without warranty of any kind. It may be used for any purpose, commercial or non-commercial, at the user's own risk. The author is not liable for any damages resulting from the use of this software. It may be redistributed and modified under the terms of the MIT License.</string>
 </dict>


### PR DESCRIPTION
## What changed

- add foreground-aware Apple Music and Spotify volume control
- smooth system-volume changes with a 120 Hz easing ramp
- add single, double, and triple click gestures for playback and opening Music
- add press-and-turn track navigation and Option-turn display brightness
- add Siri on long press and microphone mute on very long press
- default new installations to audio-control mode
- document the new 1.1.0 behavior and Apple Events permission

## Why

The Griffin PowerMate is especially useful as an always-available media controller. The existing media-key-only volume path is relatively coarse and does not provide app-aware behavior. These changes make volume control finer and allow natural button gestures while preserving system-level fallbacks for unsupported apps and devices.

## User impact

Apple Music and Spotify can be controlled directly when appropriate, while other applications continue to use system volume. Playback gestures target the active background player when Music is not in the foreground.

## Validation

- built successfully as a native arm64 release with Swift 6.3.3 on macOS 26.6
- app bundle signed ad hoc and verified with `codesign --verify --deep --strict`
- exercised against a connected Griffin PowerMate (VID 0x077d, PID 0x0410)
- verified that only one agent process seizes the HID device during testing
